### PR TITLE
Overhaul the vector code to use GNU Trove + one bug fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,12 @@
 		</dependency>
 
 
-
+                <dependency>
+                  <groupId>net.sf.trove4j</groupId>
+                  <artifactId>trove4j</artifactId>
+                  <version>3.0.3</version>
+                </dependency>
+                
 		<dependency>
 		    <groupId>edu.stanford.nlp</groupId>
 		    <artifactId>stanford-corenlp</artifactId>

--- a/src/main/java/it/uniroma1/lcl/adw/comparison/Cosine.java
+++ b/src/main/java/it/uniroma1/lcl/adw/comparison/Cosine.java
@@ -5,6 +5,11 @@ import it.uniroma1.lcl.adw.semsig.SemSig;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import gnu.trove.iterator.TFloatIterator;
+import gnu.trove.iterator.TIntFloatIterator;
+import gnu.trove.map.TIntFloatMap;
+
+
 public class Cosine implements SignatureComparison 
 {
 
@@ -14,24 +19,30 @@ public class Cosine implements SignatureComparison
 	}
 
 	public double compare(
-			LinkedHashMap<Integer, Float> v1,
-			LinkedHashMap<Integer, Float> v2,
+			TIntFloatMap v1,
+			TIntFloatMap v2,
 			boolean sorted) 
 	{
 		//sorted or not, it does not change the comparison procedure
 		return cosineSimilarity(v1, v2);
 	}
 	
-	public static double norm2(Map<Integer, Float> vector)
+	public static double norm2(TIntFloatMap vector)
 	{		
 		double norm = 0.0;
-		for(Number value : vector.values()) norm += value.doubleValue() * value.doubleValue();		
+                TFloatIterator iter = vector.valueCollection().iterator();
+                while (iter.hasNext())
+                {
+                    float f = iter.next();
+                    norm += f * f;
+                }
+                    
 		norm = Math.sqrt(norm);
 		
 		return norm;
 	}
 	
-	public static double cosineSimilarity(Map<Integer, Float> u, Map<Integer, Float> v)
+	public static double cosineSimilarity(TIntFloatMap u, TIntFloatMap v)
 	{
 		double u_norm = norm2(u);
 		if( u_norm == 0 ) return 0;
@@ -42,11 +53,11 @@ public class Cosine implements SignatureComparison
 		return dotProduct(u, v)/(u_norm * v_norm);
 	}
 	
-	public static double dotProduct(Map<Integer, Float> vector1, Map<Integer, Float> vector2)
+	public static double dotProduct(TIntFloatMap vector1, TIntFloatMap vector2)
 	{
 		double dotProduct = 0.0;
-		
-		Map<Integer, Float> temp = null;
+                
+		TIntFloatMap temp = null;
 		
 		if (vector1.size() > vector2.size())
 		{
@@ -54,13 +65,16 @@ public class Cosine implements SignatureComparison
 			vector1 = vector2;
 			vector2 = temp;
 		}
-		
-		for(int key : vector1.keySet())
+
+                TIntFloatIterator iter = vector1.iterator();
+                while (iter.hasNext()) 
 		{
-			Number value = vector2.get(key);
-			if( value == null ) continue;
-			
-			dotProduct += vector1.get(key).doubleValue() * value.doubleValue(); 
+                    iter.advance();
+                    int key = iter.key();
+                    float f = vector2.get(key);
+                    if (f == 0)
+                        continue;
+                    dotProduct += iter.value() * f;
 		}
 		
 		return dotProduct;

--- a/src/main/java/it/uniroma1/lcl/adw/comparison/Cosine.java
+++ b/src/main/java/it/uniroma1/lcl/adw/comparison/Cosine.java
@@ -49,7 +49,7 @@ public class Cosine implements SignatureComparison
 		
 		double v_norm = norm2(v);
 		if( v_norm == 0 ) return 0;
-		
+
 		return dotProduct(u, v)/(u_norm * v_norm);
 	}
 	

--- a/src/main/java/it/uniroma1/lcl/adw/comparison/Jaccard.java
+++ b/src/main/java/it/uniroma1/lcl/adw/comparison/Jaccard.java
@@ -4,9 +4,11 @@ import it.uniroma1.lcl.adw.semsig.SemSig;
 import it.uniroma1.lcl.adw.utils.SemSigUtils;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
+
+import gnu.trove.iterator.TIntIterator;
+import gnu.trove.map.TIntFloatMap;
 
 /**
  * Counts the number of overlapping dimensions across the two signatures
@@ -23,33 +25,21 @@ public class Jaccard implements SignatureComparison
 	}
 
 	public double compare(
-			LinkedHashMap<Integer, Float> v1,
-			LinkedHashMap<Integer, Float> v2,
+			TIntFloatMap v1,
+			TIntFloatMap v2,
 			boolean sorted) 
 	{
-		if(!sorted)   
-		{
-			v1 = SemSigUtils.sortVector(v1);
-			v2 = SemSigUtils.sortVector(v2);
-		}
+            int overlaps = 0;
 		
-		double overlaps = 0;
-		List<Integer> v1Keys = new ArrayList<Integer>(v1.keySet());
-		
-		Set<Integer> v2KeysSet = v2.keySet();
-		
-		for(Integer s : v1Keys)
-		{
-			if(v2KeysSet.contains(s))
-			{
-				overlaps++;
-			}
-		}
-		
-		if(overlaps == 0)
-			return 0;
-		
-		return 2.0*overlaps/(v1.size()+v2.size());
+            TIntIterator iter = v1.keySet().iterator();
+            while (iter.hasNext())
+            {
+                int key = iter.next();
+                if (v2.containsKey(key))
+                    overlaps++;
+            }
+            
+            return overlaps / (double)(v1.size() + v2.size() - overlaps);
 	}
 
 }

--- a/src/main/java/it/uniroma1/lcl/adw/comparison/JensenShannon.java
+++ b/src/main/java/it/uniroma1/lcl/adw/comparison/JensenShannon.java
@@ -2,7 +2,8 @@ package it.uniroma1.lcl.adw.comparison;
 
 import it.uniroma1.lcl.adw.semsig.SemSig;
 
-import java.util.LinkedHashMap;
+import gnu.trove.iterator.TIntFloatIterator;
+import gnu.trove.map.TIntFloatMap;
 
 public class JensenShannon implements SignatureComparison
 {
@@ -13,8 +14,8 @@ public class JensenShannon implements SignatureComparison
 	}
 
 	public double compare(
-			LinkedHashMap<Integer, Float> v1,
-			LinkedHashMap<Integer, Float> v2,
+			TIntFloatMap v1,
+			TIntFloatMap v2,
 			boolean sorted) 
 	{
 		
@@ -22,37 +23,35 @@ public class JensenShannon implements SignatureComparison
 		
 		double JS = 0.0;
 		
-		if(v1.keySet().size() == 0 || v2.keySet().size() == 0)
+		if(v1.size() == 0 || v2.size() == 0)
 			return JS;
-		
-		for(Integer key : v1.keySet())
-		{
-			double P = v1.get(key);
-			double Q = 0;
-			
-			if(v2.containsKey(key))
-			{
-				Q = v2.get(key);
-			}
 
-			Q = (P+Q)/2;
-			JS += Math.log(P/Q) * P;
-		}
-	
-		for(Integer key : v2.keySet())
-		{
-			double P = v2.get(key);
-			double Q = 0;
-			
-			if(v1.containsKey(key))
-			{
-				Q = v1.get(key);
-			}
+                TIntFloatIterator iter = v1.iterator();
+                while (iter.hasNext())
+                {
+                    iter.advance();
+                    int key = iter.key();
+                    double P = iter.value();
+                    // if v2 doesn't have the key, Q is 0
+                    double Q = v2.get(key);
+                    double M = (P + Q) / 2;
 
-			Q = (P+Q)/2;
-			JS += Math.log(P/Q) * P;
-		}
-		
+                    JS += Math.log(P/M) * P;
+                }
+
+                iter = v2.iterator();
+                while (iter.hasNext())
+                {
+                    iter.advance();
+                    int key = iter.key();
+                    double P = iter.value();
+                    // if v1 doesn't have the key, Q is 0
+                    double Q = v1.get(key);
+                    double M = (P + Q) / 2;
+
+                    JS += Math.log(P/M) * P;
+                }
+                		
 		return JS;
 	}
 

--- a/src/main/java/it/uniroma1/lcl/adw/comparison/KLDivergence.java
+++ b/src/main/java/it/uniroma1/lcl/adw/comparison/KLDivergence.java
@@ -2,40 +2,40 @@ package it.uniroma1.lcl.adw.comparison;
 
 import it.uniroma1.lcl.adw.semsig.SemSig;
 
-import java.util.LinkedHashMap;
+import gnu.trove.iterator.TIntFloatIterator;
+import gnu.trove.map.TIntFloatMap;
+
 
 public class KLDivergence implements SignatureComparison
 {
 
 	public double compare(SemSig v1, SemSig v2, boolean sorted) 
 	{
-		return compare(v1.getVector(), v2.getVector(), sorted) ;
+		return compare(v1.getVector(), v2.getVector(), sorted);
 	}
 
 	public double compare(
-			LinkedHashMap<Integer, Float> v1,
-			LinkedHashMap<Integer, Float> v2,
+			TIntFloatMap v1,
+			TIntFloatMap v2,
 			boolean sorted) 
 	{
 		//it does not matter if the vectors are sorted or not
 		
 		double DKL = 0.0;
-		
-		for(Integer key : v1.keySet())
-		{
-			double P = v1.get(key);
 
-			if(!v2.containsKey(key))
-			{
-				//System.out.println("There is no key "+key+" in the vector!");
-				//System.exit(0);
-				continue;
-			}
-
-			double Q = v2.get(key);
-			
-			DKL += Math.log(P/Q) * P;
-		}
+                TIntFloatIterator iter = v1.iterator();
+                while (iter.hasNext())
+                {
+                    iter.advance();
+                    int key = iter.key();
+                    if (!v2.containsKey(key))
+                    {
+                        continue;
+                    }
+                    double P = iter.value();
+                    double Q = v2.get(key);
+                    DKL += Math.log(P/Q) * P;
+                }
 	
 		return DKL;
 

--- a/src/main/java/it/uniroma1/lcl/adw/comparison/SignatureComparison.java
+++ b/src/main/java/it/uniroma1/lcl/adw/comparison/SignatureComparison.java
@@ -1,6 +1,6 @@
 package it.uniroma1.lcl.adw.comparison;
 
-import java.util.LinkedHashMap;
+import gnu.trove.map.TIntFloatMap;
 
 import it.uniroma1.lcl.adw.semsig.SemSig;
 
@@ -13,5 +13,5 @@ import it.uniroma1.lcl.adw.semsig.SemSig;
 public interface SignatureComparison 
 {
 	double compare(SemSig v1, SemSig v2, boolean sortedNormalized);
-	double compare(LinkedHashMap<Integer,Float> v1, LinkedHashMap<Integer,Float> v2, boolean sortedNormalized);
+	double compare(TIntFloatMap v1, TIntFloatMap v2, boolean sortedNormalized);
 }

--- a/src/main/java/it/uniroma1/lcl/adw/comparison/WeightedOverlap.java
+++ b/src/main/java/it/uniroma1/lcl/adw/comparison/WeightedOverlap.java
@@ -77,8 +77,8 @@ public class WeightedOverlap implements SignatureComparison
                 if (overlaps.isEmpty())
                     return 0;
                 
-		TIntIntMap indexToPosition1 = new TIntIntHashMap(overlaps.size());
-                TIntIntMap indexToPosition2 = new TIntIntHashMap(overlaps.size());                
+		TIntIntMap indexToPosition1 = new TIntIntHashMap(v1.length);
+                TIntIntMap indexToPosition2 = new TIntIntHashMap(v2.length);
                 for (int i = 0; i < v1.length; ++i)
                     indexToPosition1.put(v1[i], i);
                 for (int i = 0; i < v2.length; ++i)

--- a/src/main/java/it/uniroma1/lcl/adw/comparison/WeightedOverlap.java
+++ b/src/main/java/it/uniroma1/lcl/adw/comparison/WeightedOverlap.java
@@ -11,6 +11,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 
+import gnu.trove.iterator.TIntIterator;
+import gnu.trove.map.TIntFloatMap;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.hash.TIntFloatHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+
+
 /**
  * A non-parametric approach for comparing two multinomial distributions proposed in:
  * 
@@ -28,90 +37,72 @@ public class WeightedOverlap implements SignatureComparison
 {
 	public double compare(SemSig v1, SemSig v2, boolean sortedNormalized) 
 	{
-		return compare(v1.getVector(),v2.getVector(),sortedNormalized);
+            TIntSet overlap = new TIntHashSet(v1.getVector().keySet());
+            overlap.retainAll(v2.getVector().keySet());
+            return compare(overlap,
+                           v1.getSortedIndices(),
+                           v2.getSortedIndices());
 	}
 
 	public double compare(
-			LinkedHashMap<Integer, Float> v1,
-			LinkedHashMap<Integer, Float> v2,
+			TIntFloatMap v1,
+			TIntFloatMap v2,
 			boolean sorted) 
 	{
-		
-		if(!sorted)   
-		{
-			v1 = SemSigUtils.sortVector(v1);
-			v2 = SemSigUtils.sortVector(v2);
-		}
-		
-		List<Integer> v2Keys = new ArrayList<Integer>(v2.keySet());
-		List<Integer> v1Keys = new ArrayList<Integer>(v1.keySet());
-		
-		return compare(v1Keys,v2Keys);
+            TIntSet overlap = new TIntHashSet(v1.keySet());
+            overlap.retainAll(v2.keySet());
+
+            return compare(overlap,
+                           SemSigUtils.getSortedIndices(v1),
+                           SemSigUtils.getSortedIndices(v2));
 	}
 	
-	//old implementation, not suitable for truncated vectors with small overlaps
-//	public double compare(List<Integer> v1,
-//						  List<Integer> v2) 
-//	{
-//
-//		double overlaps = 0;
-//		double normalization = 0;
-//		
-//		HashMap<Integer,Integer> map = SemSigComparator.ListToMap(v2);
-//		
-//		int index = 0;
-//		
-//		for(Integer s : v1)
-//		{
-//			//works only on the overlapping dimensions of v1 and v2
-//			if(v2.contains(s))
-//			{
-//				overlaps += 1.0/((index+1)+(map.get(s)+1));	
-//				normalization += 1.0/(2*(index+1));
-//				index++;
-//			}
-//		}
-//		
-//		//if the two signatures have no dimension in common
-//		if(overlaps == 0 || normalization == 0)
-//			return 0;
-//		
-//		return overlaps/normalization;
-//	}
-	
 	/**
-	 * New implementation of Weighted Overlap that better suits the case when only a small part of two vectors overlap,
-	 * which is also the case for the provided vectors that are truncated to top-5000 elements (of the original 117,500) 
-	 * Also, to have a smoother distribution of scores, a square-root function has been added to the formula.
+	 * New implementation of Weighted Overlap that better suits the case
+	 * when only a small part of two vectors overlap, which is also the case
+	 * for the provided vectors that are truncated to top-5000 elements (of
+	 * the original 117,500) Also, to have a smoother distribution of
+	 * scores, a square-root function has been added to the formula.
+         *
 	 * @param v1 sorted list of dimensions in the first vector (smaller)
 	 * @param v2 sorted list of dimensions in the second vector (larger)
 	 * @return
 	 */
-	public static double compareSmallerWithBigger(List<Integer> v1, List<Integer> v2) 
+        public static double compareSmallerWithBigger(TIntSet overlaps, int[] v1, int[] v2) 
 	{
 		double nominator = 0;
 		double normalization = 0;
-		
-		Set<Integer> overlaps = getOverlap(v1, v2);
-		
-		HashMap<Integer,Integer> map1 = SemSigComparator.ListToMap(v1);
-		HashMap<Integer,Integer> map2 = SemSigComparator.ListToMap(v2);
-		
+
+                //if the two signatures have no dimension in common
+                if (overlaps.isEmpty())
+                    return 0;
+                
+		TIntIntMap indexToPosition1 = new TIntIntHashMap(overlaps.size());
+                TIntIntMap indexToPosition2 = new TIntIntHashMap(overlaps.size());                
+                for (int i = 0; i < v1.length; ++i)
+                    indexToPosition1.put(v1[i], i);
+                for (int i = 0; i < v2.length; ++i)
+                    indexToPosition1.put(v2[i], i);	
+               
 		int i = 1;
-		for(Integer overlap : overlaps)
+                TIntIterator iter = overlaps.iterator();
+                while (iter.hasNext()) 
 		{
+                    int overlap = iter.next();
 //			System.out.println(i+"\t"+map1.get(overlap)+1+"\t"+map2.get(overlap)+1);
-			nominator += 1.0/((map1.get(overlap)+1)+(map2.get(overlap)+1));
+
+                    nominator += 1.0 /
+                        ((indexToPosition1.get(overlap)+1) + (indexToPosition2.get(overlap)+1));
 //			nominator += 1.0/(Math.sqrt((map1.get(overlap)+1)+(map2.get(overlap)+1)));
 			
-			normalization += 1.0/((2*i));
+                    normalization += 1.0/((2*i));
 //			normalization += 1.0/(Math.sqrt(2*i));
-			i++;
+                    i++;
 		}
 		
 		//if the two signatures have no dimension in common
 		if(nominator == 0 || normalization == 0)
-			return 0;
+                    return 0;
 		
 		return ((double)nominator/normalization);
 	}
@@ -127,13 +118,13 @@ public class WeightedOverlap implements SignatureComparison
 		return overlap;
 	}
 	
-	public static double compare(List<Integer> v1, List<Integer> v2)
+        public static double compare(TIntSet overlaps, int[] v1, int[] v2)
 	{
 		//in order to normalize by the smaller vector
-		if(v1.size() > v2.size())
-			return compareSmallerWithBigger(v2, v1);
+		if(v1.length > v2.length)
+                        return compareSmallerWithBigger(overlaps, v2, v1);
 		else
-			return compareSmallerWithBigger(v1, v2);
+                        return compareSmallerWithBigger(overlaps, v1, v2);
 	}
 	
 }

--- a/src/main/java/it/uniroma1/lcl/adw/comparison/WeightedOverlap.java
+++ b/src/main/java/it/uniroma1/lcl/adw/comparison/WeightedOverlap.java
@@ -82,7 +82,7 @@ public class WeightedOverlap implements SignatureComparison
                 for (int i = 0; i < v1.length; ++i)
                     indexToPosition1.put(v1[i], i);
                 for (int i = 0; i < v2.length; ++i)
-                    indexToPosition1.put(v2[i], i);	
+                    indexToPosition2.put(v2[i], i);	
                
 		int i = 1;
                 TIntIterator iter = overlaps.iterator();

--- a/src/main/java/it/uniroma1/lcl/adw/semsig/SemSig.java
+++ b/src/main/java/it/uniroma1/lcl/adw/semsig/SemSig.java
@@ -44,6 +44,7 @@ public class SemSig
 	public void setVector(TIntFloatMap v)
 	{
 		this.vector = v;
+                this.sortedIndices = null;
 	}
 	
 	public void setOffset(String o)

--- a/src/main/java/it/uniroma1/lcl/adw/semsig/SemSig.java
+++ b/src/main/java/it/uniroma1/lcl/adw/semsig/SemSig.java
@@ -1,6 +1,12 @@
 package it.uniroma1.lcl.adw.semsig;
 
-import java.util.LinkedHashMap;
+import it.uniroma1.lcl.adw.utils.SemSigUtils;
+
+import gnu.trove.iterator.TIntFloatIterator;
+import gnu.trove.map.TIntFloatMap;
+import gnu.trove.map.hash.TIntFloatHashMap;
+
+import java.util.Collections;
 
 import edu.mit.jwi.item.POS;
 
@@ -29,12 +35,13 @@ import edu.mit.jwi.item.POS;
  */
 public class SemSig
 {
-	private LinkedHashMap<Integer,Float> vector = new LinkedHashMap<Integer,Float>();
+	private TIntFloatMap vector = new TIntFloatHashMap();
 	private String offset = "null";
 	private POS tag = null;
 	private LKB lkb = null;
-	
-	public void setVector(LinkedHashMap<Integer,Float> v)
+        private int[] sortedIndices = null;
+    
+	public void setVector(TIntFloatMap v)
 	{
 		this.vector = v;
 	}
@@ -59,16 +66,25 @@ public class SemSig
 		this.vector.put(offset, prob);
 	}
 	
-	public LinkedHashMap<Integer,Float> getVector()
+	public TIntFloatMap getVector()
 	{
 		return this.vector;
 	}
 
-	public LinkedHashMap<Integer,Float> getVector(int size)
+	public TIntFloatMap getVector(int size)
 	{
 		return this.vector;
 	}
-	
+
+        public int[] getSortedIndices()
+        {
+            if (sortedIndices == null && vector != null)
+            {
+                sortedIndices = SemSigUtils.getSortedIndices(vector);
+            }
+            return sortedIndices;
+        }
+
 	public String getOffset()
 	{
 		return this.offset;

--- a/src/main/java/it/uniroma1/lcl/adw/semsig/SemSigComparator.java
+++ b/src/main/java/it/uniroma1/lcl/adw/semsig/SemSigComparator.java
@@ -8,11 +8,13 @@ import it.uniroma1.lcl.adw.utils.SemSigUtils;
 import it.uniroma1.lcl.adw.utils.WordNetUtils;
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 
 import edu.mit.jwi.item.IWord;
 import edu.mit.jwi.item.POS;
+
+import gnu.trove.map.TIntFloatMap;
+import gnu.trove.map.hash.TIntFloatHashMap;
 
 
 public class SemSigComparator
@@ -26,8 +28,8 @@ public class SemSigComparator
 	}
 	
 	public static Double compareSortedNormalizedMaps(
-			LinkedHashMap<Integer,Float> vec1, 
-			LinkedHashMap<Integer,Float> vec2, 
+			TIntFloatMap vec1, 
+			TIntFloatMap vec2, 
 			SignatureComparison measure, 
 			int size)
 	{
@@ -49,8 +51,8 @@ public class SemSigComparator
 	}
 	
 	public static Double compare(
-			LinkedHashMap<Integer,Float> vec1, 
-			LinkedHashMap<Integer,Float> vec2, 
+			TIntFloatMap vec1, 
+			TIntFloatMap vec2, 
 			SignatureComparison measure, int size, 
 			boolean sorted,
 			boolean normalized)
@@ -67,8 +69,8 @@ public class SemSigComparator
 		
 		if(!normalized)
 		{
-			vec1 = new LinkedHashMap<Integer,Float>(SemSigUtils.normalizeVector(vec1));
-			vec2 = new LinkedHashMap<Integer,Float>(SemSigUtils.normalizeVector(vec2));
+			vec1 = new TIntFloatHashMap(SemSigUtils.normalizeVector(vec1));
+			vec2 = new TIntFloatHashMap(SemSigUtils.normalizeVector(vec2));
 		}
 		
 		//The vector should be normalized here, sorting is done within the compare implementation

--- a/src/main/java/it/uniroma1/lcl/adw/semsig/SemSigProcess.java
+++ b/src/main/java/it/uniroma1/lcl/adw/semsig/SemSigProcess.java
@@ -22,6 +22,10 @@ import org.apache.commons.logging.LogFactory;
 import edu.mit.jwi.item.IWord;
 import edu.mit.jwi.item.POS;
 
+import gnu.trove.map.TIntFloatMap;
+import gnu.trove.map.hash.TIntFloatHashMap;
+
+
 /**
  * a class to work with {@link SemSig}s
  * @author pilehvar
@@ -104,7 +108,7 @@ public class SemSigProcess
 		String offset = GeneralUtils.getOffsetFromPath(path);
 		vector.setOffset(offset);
 		
-		LinkedHashMap<Integer,Float> map = new LinkedHashMap<Integer,Float>(); 
+		TIntFloatMap map = new TIntFloatHashMap(size); 
 		
 		if(!new File(path).exists())
 		{
@@ -158,7 +162,7 @@ public class SemSigProcess
 		}
 		
 		if(size != MAX_VECTOR_SIZE)
-			map = SemSigUtils.truncateSortedVector(map,size);
+                        map = SemSigUtils.truncateVector(map, true, size, true);
 
 		vector.setVector(map);
 		

--- a/src/main/java/it/uniroma1/lcl/adw/semsig/SemSigProcess.java
+++ b/src/main/java/it/uniroma1/lcl/adw/semsig/SemSigProcess.java
@@ -121,7 +121,7 @@ public class SemSigProcess
 		try
 		{
 			BufferedReader br = new BufferedReader(new FileReader(path));
-			
+
 			float prob;
 			float lastProb = 0.0f;
 			int lineCounter = 1;
@@ -160,7 +160,8 @@ public class SemSigProcess
 		{
 			e.printStackTrace();
 		}
-		
+
+                
 		if(size != MAX_VECTOR_SIZE)
                         map = SemSigUtils.truncateVector(map, true, size, true);
 

--- a/src/main/java/it/uniroma1/lcl/adw/utils/Index.java
+++ b/src/main/java/it/uniroma1/lcl/adw/utils/Index.java
@@ -1,0 +1,25 @@
+package it.uniroma1.lcl.adw.utils;
+
+
+/**
+ * A utility class for holding a primitive key-value pair of an {@code int} and
+ * {@code float}.  {@link Index} instances are sortable where the index with the
+ * largest value will come first.
+ *  
+ * @author jurgens
+ *
+ */
+class Index implements Comparable<Index> {
+
+    public final int key;
+    public final float value;
+
+    public Index(int key, float value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public int compareTo(Index i) {
+        return -Float.compare(value, i.value);
+    }
+}

--- a/src/main/java/it/uniroma1/lcl/adw/utils/SemSigUtils.java
+++ b/src/main/java/it/uniroma1/lcl/adw/utils/SemSigUtils.java
@@ -2,6 +2,11 @@ package it.uniroma1.lcl.adw.utils;
 
 import it.uniroma1.lcl.adw.semsig.SemSig;
 
+import gnu.trove.iterator.TIntFloatIterator;
+import gnu.trove.map.TIntFloatMap;
+import gnu.trove.map.hash.TIntFloatHashMap;
+
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -14,19 +19,51 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
 
+import gnu.trove.iterator.TFloatIterator;
+import gnu.trove.iterator.TIntIterator;
+import gnu.trove.map.TIntFloatMap;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.hash.TIntFloatHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+
+
 public class SemSigUtils 
 {
 	
-	public static LinkedHashMap<Integer,Float> sortVector(Map<Integer,Float> vector)
-	{
-		LinkedHashMap<Integer,Float> sortedMap = new LinkedHashMap<Integer,Float>();
+	// public static TIntFloatMap sortVector(Map<Integer,Float> vector)
+	// {
+	// 	TIntFloatMap sortedMap = new TIntFloatMap();
 		
-		for(int key : sortByValue(vector).keySet())
-			sortedMap.put(key, vector.get(key));
+	// 	for(int key : sortByValue(vector).keySet())
+	// 		sortedMap.put(key, vector.get(key));
 		
-		return sortedMap;
-	}
-	
+	// 	return sortedMap;
+	// }
+
+    public static int[] getSortedIndices(TIntFloatMap vector)
+    {
+        // NOTE: it's probably possible to do this using purely primitive
+        // operations without having to resort to pushing things into an
+        // Index[].  However, this code is much cleaner to have and since we
+        // sort at most once per vector and the result is memoized, we don't
+        // lose too much from the Object-based sorting.
+        Index[] keyValPairs = new Index[vector.size()];
+        TIntFloatIterator iter = vector.iterator();
+        while (iter.hasNext())
+        {
+                iter.advance();
+                int key = iter.key();
+        }
+
+        Arrays.sort(keyValPairs);
+        int[] sortedIndices = new int[keyValPairs.length];
+        for (int i = 0; i < keyValPairs.length; ++i)
+            sortedIndices[i] = keyValPairs[i].key;
+        return sortedIndices;
+    }
+
 	/**
 	 * Truncates a vector to the top-n elements
 	 * @param vector
@@ -34,52 +71,64 @@ public class SemSigUtils
 	 * @param normalize
 	 * @return truncated vector
 	 */	
-	public static LinkedHashMap<Integer,Float> truncateVector(Map<Integer,Float> vector, boolean sorted, int size, boolean normalize)
+	public static TIntFloatMap truncateVector(TIntFloatMap vector, boolean sorted, int size, boolean normalize)
 	{
-		LinkedHashMap<Integer,Float> truncatedMap = new LinkedHashMap<Integer,Float>();
-		
-		List<Integer> keys = (sorted)? new ArrayList<Integer>(vector.keySet()) : new ArrayList<Integer>(sortVector(vector).keySet());
-		
-		int i = 0;
-		for(int key : keys)
-		{
-			truncatedMap.put(key, vector.get(key));
-			
-			if(i++ >= size) break;
-		}
+		TIntFloatMap truncatedMap = new TIntFloatHashMap();
+
+                int[] sortedIndices = getSortedIndices(vector);
+
+                float valSum = 0f;
+                
+                for (int i = 0; i < size && i < sortedIndices.length; ++i)
+                {
+                    int index = sortedIndices[i];
+                    float val = vector.get(index);
+                    truncatedMap.put(index, val);
+                }
 		
 		if(normalize)
 		{
-			truncatedMap = new LinkedHashMap<Integer,Float>(normalizeVector(truncatedMap));
+                    // Iterate over all the value again and normalize.  We do
+                    // this here (in-place0 to avoid having to create another
+                    // Map instance of the truncated data.
+                    for (int i = 0; i < size && i < sortedIndices.length; ++i)
+                    {
+                            int index = sortedIndices[i];
+                            float val = vector.get(index);
+                            truncatedMap.put(index, val / valSum);
+                    }
+                    
 		}
 		
 		return truncatedMap;
 	}
 	
-	/**
-	 * Truncates a vector to the top-n elements (assumes that the input vector is already sorted)
-	 * @param vector
-	 * @param size
-	 * @param normalize
-	 * @return truncated vector
-	 */
-	public static LinkedHashMap<Integer,Float> truncateSortedVector(LinkedHashMap<Integer,Float> vector, int size)
-	{
-		LinkedHashMap<Integer,Float> sortedMap = new LinkedHashMap<Integer,Float>();
+	// /**
+	//  * Truncates a vector to the top-n elements (assumes that the input vector is already sorted)
+	//  * @param vector
+	//  * @param size
+	//  * @param normalize
+	//  * @return truncated vector
+	//  */
+	// public static TIntFloatMap truncateSortedVector(TIntFloatMap vector, int size)
+	// {
+	// 	TIntFloatMap sortedMap = new TIntFloatMap();
 		
-		int i = 1;
-		for(int key : vector.keySet())
-		{
-			sortedMap.put(key, vector.get(key));
-			if(i++ > size) break;
-		}
+	// 	int i = 1;
+	// 	for(int key : vector.keySet())
+	// 	{
+	// 		sortedMap.put(key, vector.get(key));
+	// 		if(i++ > size) break;
+	// 	}
 		
-		return new LinkedHashMap<Integer,Float>(normalizeVector(sortedMap));
-	}
+	// 	return new TIntFloatMap(normalizeVector(sortedMap));
+	// }
 
 	/**
-	 * Averages a set of semantic signatures, 
-	 * equivalent to obtaining a semantic signature by initializing the PPR from all the corresponding nodes
+	 * Averages a set of semantic signatures, equivalent to obtaining a
+	 * semantic signature by initializing the PPR from all the corresponding
+	 * nodes
+         *
 	 * @param vectors
 	 * 			a list of vectors
 	 * @return
@@ -88,36 +137,27 @@ public class SemSigUtils
 	public static SemSig averageSemSigs(List<SemSig> vectors)
 	{
 		int size = vectors.size();
-		LinkedHashMap<Integer,Float> overallVector = new LinkedHashMap<Integer,Float>();
-		
-		Set<Integer> vectorsKeyset = new HashSet<Integer>();
-		
-		for(SemSig vector : vectors)
-		{
-			if(vector != null)
-				vectorsKeyset.addAll(vector.getVector().keySet());
-		}
+		TIntFloatMap overallVector = new TIntFloatHashMap();
 
-		for(int key : vectorsKeyset)
-		{
-			float thisKeyValue = 0;
-			
-			for(SemSig vector : vectors)
-			{
-				HashMap<Integer, Float> currentV = (vector == null)? new HashMap<Integer, Float>() : vector.getVector();
-				
-				if(currentV.containsKey(key))
-					thisKeyValue += currentV.get(key);
-			}
-			
-			if(thisKeyValue == 1)
-				thisKeyValue = 0;
-			
-			thisKeyValue /= size; 
-			overallVector.put(key, thisKeyValue);
-		}
+                // Sum the vectors
+                for (SemSig ss : vectors) {
+                    TIntFloatIterator iter = ss.getVector().iterator();
+                    while (iter.hasNext()) {
+                        iter.advance();
+                        int key = iter.key();
+                        float curVal = overallVector.get(key);
+                        overallVector.put(key, curVal + iter.value());
+                    }
+                }
 
-		SemSig overallSig = new SemSig();
+                // Normalize by the number of vectors
+                TIntFloatIterator iter = overallVector.iterator();
+                while (iter.hasNext()) {
+                    iter.advance();
+                    iter.setValue(iter.value() / size);
+                }
+                
+                SemSig overallSig = new SemSig();
 		overallSig.setVector(overallVector);
 		
 		return overallSig;
@@ -129,19 +169,23 @@ public class SemSigUtils
 	 * @param vector
 	 * @return
 	 */
-	public static Map<Integer,Float> normalizeVector(Map<Integer,Float> vector)
+	public static TIntFloatMap normalizeVector(TIntFloatMap vector)
 	{
 		float total = 0;
+
+                TFloatIterator iter = vector.valueCollection().iterator();
+                while (iter.hasNext())
+                       total += iter.next();
+                
+                TIntFloatMap normalized = new TIntFloatHashMap(vector.size());
 		
-		for(int s : vector.keySet())
-			total += vector.get(s);
-		
-		Map<Integer,Float> normalizedVector = new HashMap<Integer,Float>();
-		
-		for(int s : vector.keySet())
-			normalizedVector.put(s, vector.get(s)/total);
-		
-		return normalizedVector;
+                TIntFloatIterator iter2 = vector.iterator();
+                while (iter2.hasNext())
+                {
+                        iter2.advance();
+                        normalized.put(iter2.key(), iter2.value() / total);
+                }		
+		return normalized;
 	}
 
 	public static <K, V extends Comparable<V>> Map<K, V> sortByValue(Map<K, V> map)

--- a/src/main/java/it/uniroma1/lcl/adw/utils/SemSigUtils.java
+++ b/src/main/java/it/uniroma1/lcl/adw/utils/SemSigUtils.java
@@ -51,16 +51,18 @@ public class SemSigUtils
         // lose too much from the Object-based sorting.
         Index[] keyValPairs = new Index[vector.size()];
         TIntFloatIterator iter = vector.iterator();
+        int i = 0;
         while (iter.hasNext())
         {
                 iter.advance();
-                int key = iter.key();
+                keyValPairs[i++] = new Index(iter.key(), iter.value());
         }
 
         Arrays.sort(keyValPairs);
         int[] sortedIndices = new int[keyValPairs.length];
-        for (int i = 0; i < keyValPairs.length; ++i)
+        for (i = 0; i < keyValPairs.length; ++i)
             sortedIndices[i] = keyValPairs[i].key;
+        
         return sortedIndices;
     }
 
@@ -78,14 +80,15 @@ public class SemSigUtils
                 int[] sortedIndices = getSortedIndices(vector);
 
                 float valSum = 0f;
-                
+
                 for (int i = 0; i < size && i < sortedIndices.length; ++i)
                 {
                     int index = sortedIndices[i];
                     float val = vector.get(index);
                     truncatedMap.put(index, val);
+                    valSum += val;
                 }
-		
+
 		if(normalize)
 		{
                     // Iterate over all the value again and normalize.  We do
@@ -99,7 +102,7 @@ public class SemSigUtils
                     }
                     
 		}
-		
+
 		return truncatedMap;
 	}
 	

--- a/src/test/java/it/uniroma1/lcl/adw/utils/SemSigUtilsTest.java
+++ b/src/test/java/it/uniroma1/lcl/adw/utils/SemSigUtilsTest.java
@@ -1,0 +1,71 @@
+package it.uniroma1.lcl.adw.utils;
+
+import static org.junit.Assert.*;
+import it.uniroma1.lcl.adw.comparison.Cosine;
+import it.uniroma1.lcl.adw.comparison.SignatureComparison;
+import it.uniroma1.lcl.adw.comparison.WeightedOverlap;
+
+import org.junit.Test;
+
+import gnu.trove.iterator.TFloatIterator;
+import gnu.trove.iterator.TIntIterator;
+import gnu.trove.map.TIntFloatMap;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.hash.TIntFloatHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+
+
+public class SemSigUtilsTest
+{
+	
+	@Test
+	public void testGetSortedIndices() 
+	{
+            TIntFloatMap m = new TIntFloatHashMap();
+            m.put(0, 1f);
+            m.put(1, 10f);
+            m.put(2, 5f);
+            m.put(3, 2f);
+
+            int[] sorted = SemSigUtils.getSortedIndices(m);
+            assertEquals(4, sorted.length);
+            assertEquals(1, sorted[0]);
+            assertEquals(2, sorted[1]);
+            assertEquals(3, sorted[2]);
+            assertEquals(0, sorted[3]);
+        }
+
+    	@Test
+	public void testTruncateVector() 
+	{
+            TIntFloatMap m = new TIntFloatHashMap();
+            m.put(0, 1f);
+            m.put(1, 10f);
+            m.put(2, 5f);
+            m.put(3, 2f);
+
+            TIntFloatMap truncated = SemSigUtils.truncateVector(m, false, 2, false);
+            assertEquals(2, truncated.size());
+            assertEquals(10f, truncated.get(1), 0.1f);
+            assertEquals(5f, truncated.get(2), 0.1f);
+        }
+
+    	@Test
+	public void testTruncateVectorNormalized() 
+	{
+            TIntFloatMap m = new TIntFloatHashMap();
+            m.put(0, 1f);
+            m.put(1, 10f);
+            m.put(2, 5f);
+            m.put(3, 2f);
+
+            TIntFloatMap truncated = SemSigUtils.truncateVector(m, false, 2, true);
+            assertEquals(2, truncated.size());
+            assertEquals(10f / 15f, truncated.get(1), 0.1f);
+            assertEquals(5f / 15f, truncated.get(2), 0.1f);            
+        }
+    
+}
+            


### PR DESCRIPTION
This changeset should significantly improve all the speed of vector-based operations by eliminating the need to reify their primitive values for storage in a java.util.Map instance.  I've had to tweak the code slightly because LinkedHashMap is not longer usable for maintaining the vectors in sorted order. 

This also fixes a bug in the Jaccard Index code.

It would be good to test this code more too, which I seem to have trouble doing due to config/ directory issues. :(